### PR TITLE
Return positive gaussian width in curve_fit

### DIFF
--- a/spirou/sandbox/ccf_tools/ccf2rv.py
+++ b/spirou/sandbox/ccf_tools/ccf2rv.py
@@ -1194,8 +1194,20 @@ def run_gaussian_method(tbl, ccf_files, ccf_RV, mean_ccf, replace_rv=True):
     imin = np.argmin(np.nanmedian(mean_ccf, axis=1))
 
     for i in range(len(ccf_files)):
+        # initial guess
         p0 = [ccf_RV[imin], 1, 1, -0.1]
-        fit, pcov = curve_fit(gauss, ccf_RV, mean_ccf[:, i], p0=p0)
+
+        # bounds
+        low = np.full(len(p0), -np.inf)
+        low[1] = 0.0  # Ensure width is positive
+        high = np.full(len(p0), np.inf)
+
+        fit, pcov = curve_fit(
+                gauss,
+                ccf_RV,
+                mean_ccf[:, i],
+                p0=p0,
+                bounds=(low, high))
 
         if replace_rv:
             tbl['RV'][i] = fit[0]

--- a/spirou/sandbox/ccf_tools/ccf2rv.py
+++ b/spirou/sandbox/ccf_tools/ccf2rv.py
@@ -1197,17 +1197,12 @@ def run_gaussian_method(tbl, ccf_files, ccf_RV, mean_ccf, replace_rv=True):
         # initial guess
         p0 = [ccf_RV[imin], 1, 1, -0.1]
 
-        # bounds
-        low = np.full(len(p0), -np.inf)
-        low[1] = 0.0  # Ensure width is positive
-        high = np.full(len(p0), np.inf)
-
         fit, pcov = curve_fit(
                 gauss,
                 ccf_RV,
                 mean_ccf[:, i],
                 p0=p0,
-                bounds=(low, high))
+                )
 
         if replace_rv:
             tbl['RV'][i] = fit[0]
@@ -1216,7 +1211,7 @@ def run_gaussian_method(tbl, ccf_files, ccf_RV, mean_ccf, replace_rv=True):
         # template, we keep a RV that is specific to this method
         tbl['RV_GAUSS'][i] = fit[0]
 
-        tbl['GAUSS_WIDTH'][i] = fit[1]
+        tbl['GAUSS_WIDTH'][i] = np.abs(fit[1])  # Make sure positive width
         tbl['GAUSS_AMP'][i] = fit[3]
         tbl['GAUSS_ZP'][i] = fit[2]
 


### PR DESCRIPTION
As pointed out in #16, the Gaussian method for calculating RVs sometimes yields a negative value for the width. To avoid this, I added a lower bound at 0.0 for the width in `curve_fit`. Here is an example with Gl699:

Without bounds:
![image](https://user-images.githubusercontent.com/35547958/96837173-feff2400-1413-11eb-924d-95bdfc23984e.png)

With bounds:
![image](https://user-images.githubusercontent.com/35547958/96837386-58ffe980-1414-11eb-808c-56739ce63734.png)
