### PR TITLE
add plot of RV timeseries at the end of get_object_rv

### DIFF
--- a/spirou/sandbox/ccf_tools/ccf2rv.py
+++ b/spirou/sandbox/ccf_tools/ccf2rv.py
@@ -456,6 +456,13 @@ def get_object_rv(obj=None,
                 showplots=showplots,
                 )
 
+        plot_rv_timeseries(
+                tbl,
+                batch_name,
+                saveplots=saveplots,
+                showplots=showplots,
+                )
+
     # output to csv file
     if save_result_table:
         tbl.write('{0}.csv'.format(batch_name), overwrite=True)
@@ -616,6 +623,20 @@ def timeseries_to_csv(
         raise ValueError('rv_units should be m/s or km/s')
 
     df.to_csv(savepath, index=False)
+
+
+def plot_rv_timeseries(tbl, batch_name, saveplots=False, showplots=False):
+    fig = plt.figure()
+    plt.errorbar(tbl['MJDATE'], tbl['RV'], tbl['ERROR_RV'],
+                 fmt='ko', capsize=2)
+    plt.title('RV Timeseries')
+    plt.xlabel('MJDATE')
+    plt.ylabel('RV [km/s]')
+    if saveplots:
+        plt.savefig('{0}_RV.pdf'.format(batch_name))
+    if showplots:
+        plt.show()
+    plt.close(fig)
 
 
 def gauss(v, v0, ew, zp, amp):
@@ -1174,7 +1195,7 @@ def plot_bisector_method(tbl, batch_name, saveplots=False, showplots=False):
               ylabel='slope [km/s/fract. depth]')
     plt.tight_layout()
     if saveplots:
-        plt.savefig('{0}_RV.pdf'.format(batch_name))
+        plt.savefig('{0}_bis_RV.pdf'.format(batch_name))
     if showplots:
         plt.show()
     plt.close(fig)
@@ -1234,7 +1255,7 @@ def plot_gaussian_method(tbl, batch_name, saveplots=False, showplots=False):
               ylabel='Gaussian FWHM [km/s]')
     plt.tight_layout()
     if saveplots:
-        plt.savefig('{0}_RV.pdf'.format(batch_name))
+        plt.savefig('{0}_gauss_RV.pdf'.format(batch_name))
     if showplots:
         plt.show()
     plt.close(fig)

--- a/spirou/sandbox/ccf_tools/getrv_utils.py
+++ b/spirou/sandbox/ccf_tools/getrv_utils.py
@@ -183,7 +183,8 @@ def parse_clargs():
             '--median',
             action='store_true',
             default=argparse.SUPPRESS,
-            help='Use median and error from MAD for binned RV timeseries.'
+            help='Use median and error from MAD for binned RV timeseries. '
+                 'By default, the weighted averge is used.'
             )
     parser.add_argument(
             '--show-plots',


### PR DESCRIPTION
I simply added a plot of RV vs time (with errorbars) at the end of the get_object_rv function. This simply provides an overview of the final timeseries and of the errrobars, independently of the method used for RV calculation.

PS: I added @njcuk9999 as a reviewer just in case, because I think Étienne is away this week. 