### PR TITLE
Fix empty 2mass and Gaia

### DIFF
--- a/general/object_id/maintenance.py
+++ b/general/object_id/maintenance.py
@@ -330,7 +330,8 @@ def get_2mass_id(df_sheet):
     """
     Search 2MASS ID of objects
     """
-    mask = df_sheet['TWOMASSID'].isnull()
+    # Avoid crashing gaia query
+    mask = df_sheet['TWOMASSID'].isnull() & df_sheet.GAIADR2ID.notnull()
 
     df_sheet[mask] = ut.twomass_from_gaia(df_sheet[mask])
 

--- a/general/object_id/utils.py
+++ b/general/object_id/utils.py
@@ -620,17 +620,17 @@ def twomass_from_simbad(df):
     """
     Check simbad aliases for missing 2mass ids
     """
-    print(df.index[df['2MASSID'].isna()])
+    print(df.index[df['TWOMASSID'].isna()])
     print(df.ALIASES)
-    for i in df.index[df['2MASSID'].isna()]:
+    for i in df.index[df['TWOMASSID'].isna()]:
         aliases = df['ALIASES'].loc[i].split('|')
         count = 0
         for alias in aliases:
-            if '2MASS' in alias:
+            if 'TWOMASSID' in alias:
                 twomass = alias
                 count += 1
         if count == 1:
-            df['2MASSID'].iloc[i] = twomass.split('J')[1]
+            df['TWOMASSID'].iloc[i] = twomass.split('J')[1]
             df['COMMENTS'].iloc[i] = (df['COMMENTS'].iloc[i]
                                       + ' 2MASS ID from SIMBAD'
                                       )


### PR DESCRIPTION
With the last object in the Need Sorting list, I found a bug in the update script when both Gaia and 2MASS were not available (crash in a Gaia Tap Query because these objects were not filtered out). I fixed this by masking these objects. For now it only occurs for one object (the last one I just sorted, HST10) which is why I had not noticed before.