### PR TITLE
Handle missing header keys in ARI

### DIFF
--- a/general/apero_reduction_interface/nirps_offline_profiles.yaml
+++ b/general/apero_reduction_interface/nirps_offline_profiles.yaml
@@ -106,10 +106,12 @@ headers:
       key: HIERARCH ESO TEL AMBI FWHM START
       label: Seeing at start
       dtype: float
+      fallback: Null
     EXT_AIRMASS:
       key: HIERARCH ESO TEL AIRM START
       label: Airmass at start
       dtype: float
+      fallback: Null
     EXT_EXPTIME:
         key: EXPTIME
         label: Exposure Time

--- a/general/apero_reduction_interface/nirps_online_profiles.yaml
+++ b/general/apero_reduction_interface/nirps_online_profiles.yaml
@@ -102,14 +102,18 @@ headers:
       key: DPRTYPE
       label: 'DPR TYPE'
       dtype: str
+    # Added fallback values because key missing from some files
+    # (2023-10-29 NIRPS HA, as of 2023-10-30)
     EXT_SEEING:
       key: HIERARCH ESO TEL AMBI FWHM START
       label: Seeing at start
       dtype: float
+      fallback: Null
     EXT_AIRMASS:
       key: HIERARCH ESO TEL AIRM START
       label: Airmass at start
       dtype: float
+      fallback: Null
     EXT_EXPTIME:
         key: EXPTIME
         label: Exposure Time

--- a/general/apero_reduction_interface/nirps_profiles.yaml
+++ b/general/apero_reduction_interface/nirps_profiles.yaml
@@ -120,10 +120,12 @@ headers:
       key: HIERARCH ESO TEL AMBI FWHM START
       label: Seeing at start
       dtype: float
+      fallback: Null
     EXT_AIRMASS:
       key: HIERARCH ESO TEL AIRM START
       label: Airmass at start
       dtype: float
+      fallback: Null
     EXT_EXPTIME:
         key: EXPTIME
         label: Exposure Time

--- a/general/apero_reduction_interface/nirps_profiles_test.yaml
+++ b/general/apero_reduction_interface/nirps_profiles_test.yaml
@@ -120,10 +120,12 @@ headers:
       key: HIERARCH ESO TEL AMBI FWHM START
       label: Seeing at start
       dtype: float
+      fallback: Null
     EXT_AIRMASS:
       key: HIERARCH ESO TEL AIRM START
       label: Airmass at start
       dtype: float
+      fallback: Null
     EXT_EXPTIME:
         key: EXPTIME
         label: Exposure Time

--- a/general/apero_reduction_interface/simple_ari.py
+++ b/general/apero_reduction_interface/simple_ari.py
@@ -2866,7 +2866,7 @@ def add_obj_pages(gsettings: dict, settings: dict, profile: dict,
             # run the pool
             results = add_obj_page(*itargs)
             # push result to result storage
-            results_dict[key] = results
+            results_dict[key] = results[it]
     # -------------------------------------------------------------------------
     elif n_cores > 1:
         if MULTI == 'POOL':

--- a/general/apero_reduction_interface/simple_ari.py
+++ b/general/apero_reduction_interface/simple_ari.py
@@ -4346,8 +4346,24 @@ def _header_value(keydict: Dict[str, str], header: fits.Header,
     rawvalue = header.get(key, None)
     # deal with no value
     if rawvalue is None:
-        raise ValueError(f'HeaderKey: {key} not found in header'
-                         f'\n\tFile: {filename}')
+        if "fallback" in keydict:
+            rawvalue = keydict["fallback"]
+            if rawvalue is None:
+                if dtype == 'float':
+                    rawvalue = np.nan
+                elif dtype == 'str':
+                    rawvalue = "N.A."
+                else:
+                    # Hard to define an unambiguous value for other types.
+                    # Leaving as unsupported until the need arises.
+                    raise TypeError('Null (None) fallback value unsupported'
+                                    f' for dtype {dtype} (key {key})'
+                                    f'\n\tFile: {filename}'
+                    )
+        else:
+            raise ValueError(f'HeaderKey: {key} not found in header'
+                             ' and no fallback specified in config'
+                             f'\n\tFile: {filename}')
     # -------------------------------------------------------------------------
     # deal with dtype
     if dtype is not None:

--- a/general/apero_reduction_interface/simple_ari.py
+++ b/general/apero_reduction_interface/simple_ari.py
@@ -1175,6 +1175,7 @@ class ObjectData:
             num_obs_ext = str(np.sum(obs_mask_ext))
             num_obs_tcorr = str(np.sum(obs_mask_tcorr))
             # get the seeing for this observation directory
+            # TODO: nanmean for all below?
             seeing = np.mean(seeing_vec[obs_mask_ext])
             seeing = '{:.3f}'.format(seeing)
             # get the airmass for this observation directory

--- a/nirps/apero_check/check_ha_headers.py
+++ b/nirps/apero_check/check_ha_headers.py
@@ -19,6 +19,9 @@ for key in hdr2:
         missing_from_1.append(key)
 
 # %%
+print(f"File 1: {FILE1}")
+print(f"File 2: {FILE2}")
+# %%
 print("Keys in 2 not in 1:")
 pprint.pprint(missing_from_1)
 

--- a/nirps/apero_check/check_ha_headers.py
+++ b/nirps/apero_check/check_ha_headers.py
@@ -6,7 +6,7 @@ FILE1 = "/nirps_raw/nirps/raw-data/nirps_he/2023-10-29/NIRPS_2023-10-30T00_15_11
 FILE2 = "/nirps_raw/nirps/raw-data/nirps_ha/2023-10-29/NIRPS_2023-10-30T00_02_55_544.fits"
 
 hdr1 = fits.getheader(FILE1)
-hdr2 = fits.getheader(FILE1)
+hdr2 = fits.getheader(FILE2)
 
 # %%
 missing_from_2 = []

--- a/nirps/apero_check/check_ha_headers.py
+++ b/nirps/apero_check/check_ha_headers.py
@@ -1,3 +1,4 @@
+# TODO: Implement a proper test for this. This is for quick reporting of missing header keys.
 # %%
 from astropy.io import fits
 import pprint

--- a/nirps/apero_check/check_ha_headers.py
+++ b/nirps/apero_check/check_ha_headers.py
@@ -1,0 +1,28 @@
+# %%
+from astropy.io import fits
+import pprint
+
+FILE1 = "/nirps_raw/nirps/raw-data/nirps_he/2023-10-29/NIRPS_2023-10-30T00_15_11_266.fits"
+FILE2 = "/nirps_raw/nirps/raw-data/nirps_ha/2023-10-29/NIRPS_2023-10-30T00_02_55_544.fits"
+
+hdr1 = fits.getheader(FILE1)
+hdr2 = fits.getheader(FILE1)
+
+# %%
+missing_from_2 = []
+for key in hdr1:
+    if key not in hdr2:
+        missing_from_2.append(key)
+missing_from_1 = []
+for key in hdr2:
+    if key not in hdr1:
+        missing_from_1.append(key)
+
+# %%
+print("Keys in 2 not in 1:")
+pprint.pprint(missing_from_1)
+
+# %%
+
+print("Keys in 1 not in 2:")
+pprint.pprint(missing_from_2)

--- a/nirps/manual_trigger/manual_trigger.py
+++ b/nirps/manual_trigger/manual_trigger.py
@@ -751,7 +751,7 @@ if __name__ == "__main__":
         run_apero_reduction_interface(trigger_settings)
         # deal with only running processing
         if trigger_settings['ONLY_REDUCTIONINTERFACE']:
-            print_process('Only running apero get')
+            print_process('Only running ARI')
             sys.exit(0)
     # ----------------------------------------------------------------------
     # log that we have finished


### PR DESCRIPTION
This fixes the issue we had earlier today with ARI crashing when a header key was missing. Ideally the error keys still should not be missing, and for some of them it's critical that they are present. Therefore, the mechanism I implemented has to be enabled explicitly for a given header key, otherwise ARI will still crash with the same error as before.

The PR includes:

- Code to handle fallback values for header keys when running ARI
- Updated ARI profiles with fallback values set to `Null` (YAML's `None`) for seeing and airmass
- A "check" script to report missing header keys, I used this to diagnose and figured it might be useful as a temporary helper script. **This should be converted to a proper RAW check**

One last thing to decide: **Should the `np.mean()` calls be replaced by `np.nanmean()` so that missing header keys don't affect summary stats? It seems like the best option, but I wanted to check that none of these reports was sometimes expected to return NaN when one of the values is a NaN**

Also, please wait before merging: I did not run the "saving" part with this version of the code yet, in case we made other changes, so I'll try this once locally before merging into `developer`, then I'll merge.