### PR TITLE
Update lower flux limit for WAVE,UN1,FP in CALIB_QUAL

### DIFF
--- a/nirps/apero_check/apero_checks/raw_tests/qual_test.py
+++ b/nirps/apero_check/apero_checks/raw_tests/qual_test.py
@@ -58,7 +58,7 @@ constraints['CONTAM,DARK,FP'] = 10, 1000, 0.0004
 constraints['WAVE,FP,FP'] = 10, 1000, 0.0004
 constraints['WAVE,UN1,UN1'] = 5, 100, 0.0025
 constraints['WAVE,FP,UN1'] = 5, 100, 0.0012
-constraints['WAVE,UN1,FP'] = 5, 100, 0.0023
+constraints['WAVE,UN1,FP'] = 4, 100, 0.0023
 
 
 def sat_test(filename, nread, dprtype) -> Tuple[bool, str]:


### PR DESCRIPTION
Limit lowered from 5 to 4 for the 99th percentile flux test, only for WAVE,UN1,FP DPR types. This is to prevent false positive failures that have been happening a few times lately in CALIB_QUAL. A few HA calib files with 99th percentile ~ 4.9 triggered failures despite looking normal in DS9. Verified that a problem with either the FP lamp or the UN lamp would result in values lowered than 4 and still trigger a CALIB_QUAL failure as intended.