### PR TITLE
Enable setting N_CORES per profile in ARI

### DIFF
--- a/general/apero_reduction_interface/nirps_profiles.yaml
+++ b/general/apero_reduction_interface/nirps_profiles.yaml
@@ -7,7 +7,8 @@ settings:
   # Finder charts (None if not needed)
   find directory: /cosmos99/nirps/apero-data/misc/apero-find/
   # number of cores to use in multiprocessing steps
-  N_CORES: 10
+  # NOTE: If uncommented, will override per-profile settings
+  # N_CORES: 10
   # Spectrum wavelength ranges in nm
   SpecWave:
     limit0:
@@ -53,6 +54,7 @@ nirps he online:
     skip obj table: False
     skip recipe table: False
     skip msg table: True
+    N_CORES: 18
 
 nirps ha online:
     apero profile: /cosmos99/nirps/apero-settings/nirps_ha_online
@@ -60,6 +62,7 @@ nirps ha online:
     skip obj table: False
     skip recipe table: False
     skip msg table: True
+    N_CORES: 2
 
 nirps he offline:
     apero profile: /cosmos99/nirps/apero-settings/nirps_he_offline
@@ -67,6 +70,7 @@ nirps he offline:
     skip obj table: False
     skip recipe table: False
     skip msg table: True
+    N_CORES: 18
 
 nirps ha offline:
     apero profile: /cosmos99/nirps/apero-settings/nirps_ha_offline
@@ -74,6 +78,7 @@ nirps ha offline:
     skip obj table: False
     skip recipe table: False
     skip msg table: True
+    N_CORES: 2
 
 # -----------------------------------------------------------------------------
 # Header keys

--- a/general/apero_reduction_interface/simple_ari.py
+++ b/general/apero_reduction_interface/simple_ari.py
@@ -2855,7 +2855,9 @@ def add_obj_pages(gsettings: dict, settings: dict, profile: dict,
     # set up the arguments for the multiprocessing
     args = [0, '', profile, gsettings, settings, headers, object_classes]
     # get the number of cores
-    n_cores = gsettings['N_CORES']
+    n_cores = gsettings.get('N_CORES', profile.get('N_CORES', None))
+    if n_cores is None:
+        raise ValueError('Must define N_CORES in settings or profile')
     # storage for results
     results_dict = dict()
     # -------------------------------------------------------------------------

--- a/general/apero_reduction_interface/simple_ari.py
+++ b/general/apero_reduction_interface/simple_ari.py
@@ -110,6 +110,8 @@ LBL_STAT_FILES['LBL Diagnostic Plots'] = 'lbl_{0}_plots.pdf'
 LBL_STAT_FILES['LBL BERV zp RDB file'] = 'lbl_{0}_bervzp.rdb'
 LBL_STAT_FILES['LBL BERV zp RDB2 file'] = 'lbl2_{0}_bervzp.rdb'
 LBL_STAT_FILES['LBL BERV Zp Diaganostic Plots'] = 'lbl_{0}_bervzp_plots.pdf'
+LBL_STAT_FILES['LBL-PCA RDB file'] = 'lbl_{0}_PCAx.rdb'
+LBL_STAT_FILES['LBL-PCA RDB2 file'] = 'lbl2_{0}_PCAx.rdb'
 # define how many ccf files to use
 MAX_NUM_CCF = 100
 # object page styling


### PR DESCRIPTION
Right now `N_CORES` is set for all profiles at once in ARI. This enables setting it per core. The behavior is:

- Check if it's in `settings`. If yes, use that
- If not, check if in the profile dictionary and use that
- If neither, raise an error.

I still need to run this on the server to make sure it works. Doing this right now and will mark ready to merge once OK

cc: @alexandrineLH and @CharlesCadieux 